### PR TITLE
Change timestamp from int to datetime on users

### DIFF
--- a/db/migrate/20181213235950_convert_timestamps_to_date_time_in_users.rb
+++ b/db/migrate/20181213235950_convert_timestamps_to_date_time_in_users.rb
@@ -1,0 +1,10 @@
+class ConvertTimestampsToDateTimeInUsers < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :users, :created_at
+    remove_column :users, :updated_at
+    add_timestamps :users, null: true
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20181214005934_make_timestamps_on_users_not_nullable.rb
+++ b/db/migrate/20181214005934_make_timestamps_on_users_not_nullable.rb
@@ -1,0 +1,8 @@
+class MakeTimestampsOnUsersNotNullable < ActiveRecord::Migration[5.0]
+  def up
+    change_column_null :users, :created_at, false
+    change_column_null :users, :updated_at, false
+  end
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181213235950) do
+ActiveRecord::Schema.define(version: 20181214005934) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -103,8 +103,8 @@ ActiveRecord::Schema.define(version: 20181213235950) do
     t.integer  "friends_updated_at"
     t.boolean  "closed_only",             default: false
     t.boolean  "deleted",                 default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.index ["twitter_id"], name: "idx_ti_on_users", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181124104509) do
+ActiveRecord::Schema.define(version: 20181213235950) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -84,27 +84,27 @@ ActiveRecord::Schema.define(version: 20181124104509) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.string  "uid",                                     null: false
-    t.bigint  "twitter_id",                              null: false
-    t.string  "provider",                                null: false
-    t.string  "name",                                    null: false
-    t.string  "screen_name",                             null: false
-    t.boolean "protected",               default: false, null: false
-    t.string  "profile_image_url_https",                 null: false
-    t.string  "time_zone"
-    t.integer "utc_offset"
-    t.integer "twitter_created_at",                      null: false
-    t.string  "lang",                                    null: false
-    t.string  "token",                                   null: false
-    t.string  "token_secret",                            null: false
-    t.boolean "finished_initial_import", default: false, null: false
-    t.integer "token_updated_at"
-    t.integer "statuses_updated_at"
-    t.integer "friends_updated_at"
-    t.boolean "closed_only",             default: false
-    t.boolean "deleted",                 default: false, null: false
-    t.integer "created_at",                              null: false
-    t.integer "updated_at",                              null: false
+    t.string   "uid",                                     null: false
+    t.bigint   "twitter_id",                              null: false
+    t.string   "provider",                                null: false
+    t.string   "name",                                    null: false
+    t.string   "screen_name",                             null: false
+    t.boolean  "protected",               default: false, null: false
+    t.string   "profile_image_url_https",                 null: false
+    t.string   "time_zone"
+    t.integer  "utc_offset"
+    t.integer  "twitter_created_at",                      null: false
+    t.string   "lang",                                    null: false
+    t.string   "token",                                   null: false
+    t.string   "token_secret",                            null: false
+    t.boolean  "finished_initial_import", default: false, null: false
+    t.integer  "token_updated_at"
+    t.integer  "statuses_updated_at"
+    t.integer  "friends_updated_at"
+    t.boolean  "closed_only",             default: false
+    t.boolean  "deleted",                 default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["twitter_id"], name: "idx_ti_on_users", using: :btree
   end
 


### PR DESCRIPTION
## 1) backup existing timestamps to redis
```ruby
User.all.each do |user|
  REDIS.set("created_at_#{user.id}", user.created_at)
  REDIS.set("updated_at_#{user.id}", user.updated_at)
end
```
## 2) change column type from int to datatime
`
bundle exec rake db:migrate VERSION=20181213235950
`
## 3) fill timestamps with those stored in redis
```ruby
User.transaction do
  User.all.each do |user|
    user.created_at = Time.at( REDIS.get("created_at_#{user.id}").to_i ).utc
    user.updated_at = Time.at( REDIS.get("updated_at_#{user.id}").to_i ).utc
    user.save!
  end
end
```
## 4) make timestamps not nullable
`
bundle exec rake db:migrate VERSION=20181214005934
`

## 5) clear data temporary stored in redis
```ruby
User.all.each do |user|
  REDIS.del("created_at_#{user.id}", "updated_at_#{user.id}")
end
```