### PR TITLE
convert timestamps on statuses

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -12,7 +12,7 @@ class Status < ApplicationRecord
 
   scope :order_for_timeline , ->{order("twitter_created_at_reversed ASC","status_id_str_reversed ASC")}
   scope :force_index , ->(index_name) {from("#{table_name} FORCE INDEX(#{index_name})")}
-  #after_save :update_user_timestamp
+  after_save :update_user_timestamp
 
   class << self
     def ordered_tweeted_unixtimes_by_user_id(user_id)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -70,8 +70,7 @@ class Status < ApplicationRecord
         text: tweet.text,
         possibly_sensitive: tweet.possibly_sensitive? || false,
         private: tweet.user.protected?,
-        deleted: false,
-        created_at: Time.now.to_i
+        deleted: false
       )
       ret.assign_retweeted_status(tweet.retweeted_status) if tweet.retweet?
       ret

--- a/db/migrate/20181215003510_rename_created_at_on_statuses.rb
+++ b/db/migrate/20181215003510_rename_created_at_on_statuses.rb
@@ -1,0 +1,8 @@
+class RenameCreatedAtOnStatuses < ActiveRecord::Migration[5.0]
+  def up
+   rename_column :statuses, :created_at, :created_at_int
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20181215003610_add_timestamps_to_statuses.rb
+++ b/db/migrate/20181215003610_add_timestamps_to_statuses.rb
@@ -1,5 +1,5 @@
 class AddTimestampsToStatuses < ActiveRecord::Migration[5.0]
   def change
-    add_timestamps :statuses, null: true
+    add_timestamps :statuses, null: false, default: -> { 'NOW()' }
   end
 end

--- a/db/migrate/20181215003610_add_timestamps_to_statuses.rb
+++ b/db/migrate/20181215003610_add_timestamps_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_timestamps :statuses, null: true
+  end
+end

--- a/db/migrate/20181215003840_add_not_null_constraint_to_timestamps_on_statuses.rb
+++ b/db/migrate/20181215003840_add_not_null_constraint_to_timestamps_on_statuses.rb
@@ -1,0 +1,6 @@
+class AddNotNullConstraintToTimestampsOnStatuses < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :statuses, :created_at, false
+    change_column_null :statuses, :updated_at, false
+  end
+end

--- a/db/migrate/20181215003840_add_not_null_constraint_to_timestamps_on_statuses.rb
+++ b/db/migrate/20181215003840_add_not_null_constraint_to_timestamps_on_statuses.rb
@@ -1,6 +1,0 @@
-class AddNotNullConstraintToTimestampsOnStatuses < ActiveRecord::Migration[5.0]
-  def change
-    change_column_null :statuses, :created_at, false
-    change_column_null :statuses, :updated_at, false
-  end
-end

--- a/db/migrate/20181215014843_remove_created_at_int_from_statuses.rb
+++ b/db/migrate/20181215014843_remove_created_at_int_from_statuses.rb
@@ -1,0 +1,8 @@
+class RemoveCreatedAtIntFromStatuses < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :statuses, :created_at_int
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20181215143603_change_default_value_for_timestamps_on_statuses.rb
+++ b/db/migrate/20181215143603_change_default_value_for_timestamps_on_statuses.rb
@@ -1,0 +1,6 @@
+class ChangeDefaultValueForTimestampsOnStatuses < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :statuses, :created_at, nil
+    change_column_default :statuses, :updated_at, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215003840) do
+ActiveRecord::Schema.define(version: 20181215014843) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 20181215003840) do
     t.integer  "rt_created_at"
     t.boolean  "possibly_sensitive",                                    null: false
     t.boolean  "private",                               default: false, null: false
-    t.integer  "created_at_int",                                        null: false
     t.integer  "deleted",                     limit: 1, default: 0,     null: false
     t.bigint   "status_id_str_reversed"
     t.integer  "twitter_created_at_reversed"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181214005934) do
+ActiveRecord::Schema.define(version: 20181215003510) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20181214005934) do
     t.integer "rt_created_at"
     t.boolean "possibly_sensitive",                                    null: false
     t.boolean "private",                               default: false, null: false
-    t.integer "created_at",                                            null: false
+    t.integer "created_at_int",                                        null: false
     t.integer "deleted",                     limit: 1, default: 0,     null: false
     t.bigint  "status_id_str_reversed"
     t.integer "twitter_created_at_reversed"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215003510) do
+ActiveRecord::Schema.define(version: 20181215003610) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -41,30 +41,32 @@ ActiveRecord::Schema.define(version: 20181215003510) do
   end
 
   create_table "statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint  "user_id",                                               null: false
-    t.bigint  "status_id_str",                                         null: false
-    t.bigint  "in_reply_to_status_id_str"
-    t.bigint  "in_reply_to_user_id_str"
-    t.string  "in_reply_to_screen_name"
-    t.string  "place_full_name"
-    t.integer "retweet_count"
-    t.integer "twitter_created_at",                                    null: false
-    t.string  "source",                                                null: false
-    t.string  "text",                                                  null: false
-    t.boolean "is_retweet",                            default: false, null: false
-    t.string  "rt_name"
-    t.string  "rt_screen_name"
-    t.string  "rt_profile_image_url_https"
-    t.string  "rt_text"
-    t.string  "rt_source"
-    t.integer "rt_created_at"
-    t.boolean "possibly_sensitive",                                    null: false
-    t.boolean "private",                               default: false, null: false
-    t.integer "created_at_int",                                        null: false
-    t.integer "deleted",                     limit: 1, default: 0,     null: false
-    t.bigint  "status_id_str_reversed"
-    t.integer "twitter_created_at_reversed"
-    t.date    "tweeted_on"
+    t.bigint   "user_id",                                                                    null: false
+    t.bigint   "status_id_str",                                                              null: false
+    t.bigint   "in_reply_to_status_id_str"
+    t.bigint   "in_reply_to_user_id_str"
+    t.string   "in_reply_to_screen_name"
+    t.string   "place_full_name"
+    t.integer  "retweet_count"
+    t.integer  "twitter_created_at",                                                         null: false
+    t.string   "source",                                                                     null: false
+    t.string   "text",                                                                       null: false
+    t.boolean  "is_retweet",                            default: false,                      null: false
+    t.string   "rt_name"
+    t.string   "rt_screen_name"
+    t.string   "rt_profile_image_url_https"
+    t.string   "rt_text"
+    t.string   "rt_source"
+    t.integer  "rt_created_at"
+    t.boolean  "possibly_sensitive",                                                         null: false
+    t.boolean  "private",                               default: false,                      null: false
+    t.integer  "created_at_int",                                                             null: false
+    t.integer  "deleted",                     limit: 1, default: 0,                          null: false
+    t.bigint   "status_id_str_reversed"
+    t.integer  "twitter_created_at_reversed"
+    t.date     "tweeted_on"
+    t.datetime "created_at",                            default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at",                            default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["status_id_str_reversed"], name: "idx_sisr_on_statuses", using: :btree
     t.index ["tweeted_on", "deleted", "private"], name: "index_statuses_on_tweeted_on_and_deleted_and_private", using: :btree
     t.index ["tweeted_on"], name: "index_statuses_on_tweeted_on", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215003610) do
+ActiveRecord::Schema.define(version: 20181215003840) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(version: 20181215003610) do
     t.bigint   "status_id_str_reversed"
     t.integer  "twitter_created_at_reversed"
     t.date     "tweeted_on"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
     t.index ["status_id_str_reversed"], name: "idx_sisr_on_statuses", using: :btree
     t.index ["tweeted_on", "deleted", "private"], name: "index_statuses_on_tweeted_on_and_deleted_and_private", using: :btree
     t.index ["tweeted_on"], name: "index_statuses_on_tweeted_on", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215003610) do
+ActiveRecord::Schema.define(version: 20181215014843) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 20181215003610) do
     t.integer  "rt_created_at"
     t.boolean  "possibly_sensitive",                                                         null: false
     t.boolean  "private",                               default: false,                      null: false
-    t.integer  "created_at_int",                                                             null: false
     t.integer  "deleted",                     limit: 1, default: 0,                          null: false
     t.bigint   "status_id_str_reversed"
     t.integer  "twitter_created_at_reversed"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215014843) do
+ActiveRecord::Schema.define(version: 20181215143603) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -41,31 +41,31 @@ ActiveRecord::Schema.define(version: 20181215014843) do
   end
 
   create_table "statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint   "user_id",                                                                    null: false
-    t.bigint   "status_id_str",                                                              null: false
+    t.bigint   "user_id",                                               null: false
+    t.bigint   "status_id_str",                                         null: false
     t.bigint   "in_reply_to_status_id_str"
     t.bigint   "in_reply_to_user_id_str"
     t.string   "in_reply_to_screen_name"
     t.string   "place_full_name"
     t.integer  "retweet_count"
-    t.integer  "twitter_created_at",                                                         null: false
-    t.string   "source",                                                                     null: false
-    t.string   "text",                                                                       null: false
-    t.boolean  "is_retweet",                            default: false,                      null: false
+    t.integer  "twitter_created_at",                                    null: false
+    t.string   "source",                                                null: false
+    t.string   "text",                                                  null: false
+    t.boolean  "is_retweet",                            default: false, null: false
     t.string   "rt_name"
     t.string   "rt_screen_name"
     t.string   "rt_profile_image_url_https"
     t.string   "rt_text"
     t.string   "rt_source"
     t.integer  "rt_created_at"
-    t.boolean  "possibly_sensitive",                                                         null: false
-    t.boolean  "private",                               default: false,                      null: false
-    t.integer  "deleted",                     limit: 1, default: 0,                          null: false
+    t.boolean  "possibly_sensitive",                                    null: false
+    t.boolean  "private",                               default: false, null: false
+    t.integer  "deleted",                     limit: 1, default: 0,     null: false
     t.bigint   "status_id_str_reversed"
     t.integer  "twitter_created_at_reversed"
     t.date     "tweeted_on"
-    t.datetime "created_at",                            default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "updated_at",                            default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
     t.index ["status_id_str_reversed"], name: "idx_sisr_on_statuses", using: :btree
     t.index ["tweeted_on", "deleted", "private"], name: "index_statuses_on_tweeted_on_and_deleted_and_private", using: :btree
     t.index ["tweeted_on"], name: "index_statuses_on_tweeted_on", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181215003510) do
+ActiveRecord::Schema.define(version: 20181215003610) do
 
   create_table "entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
     t.bigint  "status_id",              null: false
@@ -41,30 +41,32 @@ ActiveRecord::Schema.define(version: 20181215003510) do
   end
 
   create_table "statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
-    t.bigint  "user_id",                                               null: false
-    t.bigint  "status_id_str",                                         null: false
-    t.bigint  "in_reply_to_status_id_str"
-    t.bigint  "in_reply_to_user_id_str"
-    t.string  "in_reply_to_screen_name"
-    t.string  "place_full_name"
-    t.integer "retweet_count"
-    t.integer "twitter_created_at",                                    null: false
-    t.string  "source",                                                null: false
-    t.string  "text",                                                  null: false
-    t.boolean "is_retweet",                            default: false, null: false
-    t.string  "rt_name"
-    t.string  "rt_screen_name"
-    t.string  "rt_profile_image_url_https"
-    t.string  "rt_text"
-    t.string  "rt_source"
-    t.integer "rt_created_at"
-    t.boolean "possibly_sensitive",                                    null: false
-    t.boolean "private",                               default: false, null: false
-    t.integer "created_at_int",                                        null: false
-    t.integer "deleted",                     limit: 1, default: 0,     null: false
-    t.bigint  "status_id_str_reversed"
-    t.integer "twitter_created_at_reversed"
-    t.date    "tweeted_on"
+    t.bigint   "user_id",                                               null: false
+    t.bigint   "status_id_str",                                         null: false
+    t.bigint   "in_reply_to_status_id_str"
+    t.bigint   "in_reply_to_user_id_str"
+    t.string   "in_reply_to_screen_name"
+    t.string   "place_full_name"
+    t.integer  "retweet_count"
+    t.integer  "twitter_created_at",                                    null: false
+    t.string   "source",                                                null: false
+    t.string   "text",                                                  null: false
+    t.boolean  "is_retweet",                            default: false, null: false
+    t.string   "rt_name"
+    t.string   "rt_screen_name"
+    t.string   "rt_profile_image_url_https"
+    t.string   "rt_text"
+    t.string   "rt_source"
+    t.integer  "rt_created_at"
+    t.boolean  "possibly_sensitive",                                    null: false
+    t.boolean  "private",                               default: false, null: false
+    t.integer  "created_at_int",                                        null: false
+    t.integer  "deleted",                     limit: 1, default: 0,     null: false
+    t.bigint   "status_id_str_reversed"
+    t.integer  "twitter_created_at_reversed"
+    t.date     "tweeted_on"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["status_id_str_reversed"], name: "idx_sisr_on_statuses", using: :btree
     t.index ["tweeted_on", "deleted", "private"], name: "index_statuses_on_tweeted_on_and_deleted_and_private", using: :btree
     t.index ["tweeted_on"], name: "index_statuses_on_tweeted_on", using: :btree


### PR DESCRIPTION
- [ ] 1) rename existing `created_at` (int) on `statuses`
`
bundle exec rake db:migrate VERSION=20181215003510
`

- [ ] 2) add timestamps (datetime) to `statuses` with default values set to `CURRENT_TIMESTAMP` for now
`
bundle exec rake db:migrate VERSION=20181215003610
`

- [ ] 3) update `created_at` with real value ( saved on `created_at_int` as unixtime )
```sql
UPDATE statuses SET created_at = from_unixtime(created_at_int - 32400);
```

- [ ] 4) drop `created_at_int` on `statuses`
`
bundle exec rake db:migrate VERSION=20181215014843
`

- [ ] 5) change default value on timestamps
`
bundle exec rake db:migrate VERSION=20181215143603
`

