### PR TITLE
Workaround for e2e crash on CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,7 +61,7 @@ jobs:
         yarn test:ci
 
   E2E:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       CYPRESS_baseUrl: http://localhost:3000
     steps:


### PR DESCRIPTION
closes https://github.com/tbotaq/jump-pm/issues/452
