### PR TITLE
Make the link to public timeline a normal anchor tag.

### DIFF
--- a/frontend/src/components/Top.tsx
+++ b/frontend/src/components/Top.tsx
@@ -122,8 +122,7 @@ const Top: React.FC<Props> = ({ setApiErrorCode, classes }) => {
                       fullWidth
                       variant="contained"
                       color="primary"
-                      component={ Link }
-                      to={ PUBLIC_TIMELINE_PATH }
+                      href={ PUBLIC_TIMELINE_PATH }
                     >
                       公開タイムラインを見てみる
                       <InputIcon


### PR DESCRIPTION
closes https://github.com/tbotaq/jump-pm/issues/458

